### PR TITLE
Update version in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0.0)
 
 project(nlohmann_fifo_map
   LANGUAGES CXX
-  VERSION "0.0.0-0dfbf5d")
+  VERSION "0.0.0")
 
 include_directories(
     src


### PR DESCRIPTION
@ruslo Apparently CMake doesn't like a non-standard version number, this should fix it.

```
 CMake Error at CMakeLists.txt:3 (project):
    VERSION "0.0.0-0dfbf5d" format invalid.
```